### PR TITLE
[#57] Minor update to case-study-cta block

### DIFF
--- a/blocks/case-study-cta/case-study-cta.css
+++ b/blocks/case-study-cta/case-study-cta.css
@@ -69,6 +69,9 @@
   max-width: 360px;
 }
 
+.section-layout-services-case-study .image-column img {
+  max-height: 610px;
+}
 
 @media (max-width: 600px) {
   .section-layout-home-case-study.stacked-card-display-container {


### PR DESCRIPTION
Fix #57

Used existing Case Study CTA block and classname conventions for dark bg and white text

Test URLs:
- Before: [https://main--tbx-olympus--solomon71.hlx.live/services/ ](https://main--tbx-olympus--solomon71.hlx.live/services/)
- After: [https://case-study-cta--tbx-olympus--solomon71.hlx.page/services/](https://case-study-cta--tbx-olympus--solomon71.hlx.page/services/)
